### PR TITLE
Update ESPHelper.cpp

### DIFF
--- a/src/ESPHelper.cpp
+++ b/src/ESPHelper.cpp
@@ -265,7 +265,7 @@ void ESPHelper::reconnect() {
 				debugPrint("Attemping MQTT connection");
 
 				//if connected, subscribe to the topic(s) we want to be notified about
-				if (client.connect((char*) _clientName.c_str())) {
+				if (client.connect((char*) _clientName.c_str(),_currentNet.mqttUsername, _currentNet.mqttPassword)) {
 					debugPrintln(" -- Connected");
 					// _connected = true;
 					_connectionStatus = FULL_CONNECTION;


### PR DESCRIPTION
changed the client.connect() to accept MQTT username & password
Still working, if no user and password is set.