### PR TITLE
Add missing keyword identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -46,7 +46,7 @@ getIPAddress 	KEYWORD2
 getNetInfo	KEYWORD2
 setNetInfo	KEYWORD2
 setHopping	KEYWORD2
-listSubscriptions
+listSubscriptions	KEYWORD2
 heartbeat 	KEYWORD2
 enableHeartbeat	KEYWORD2
 disableHeartbeat	KEYWORD2


### PR DESCRIPTION
The identifier for the `listSubscriptions` keyword was missing, causing the Arduino IDE to not highlight that keyword.