### PR TITLE
New feature: Ability to use a custom CA certificate for MQTT broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Useful Methods:
 
 * void OTA_setHostname(char* hostname); //give a hostname to the device for OTA identification
 
+* void useCustomCaCert(const char* cert); //path to a DER certificate stored on the SPIFFS filesystem
+
 ToDo:
 -----
 

--- a/src/ESPHelper.cpp
+++ b/src/ESPHelper.cpp
@@ -197,7 +197,18 @@ bool ESPHelper::begin(){
 		//as long as an mqtt ip has been set create an instance of PubSub for client
 		if(_mqttSet){
 			//make mqtt client use either the secure or non-secure wifi client depending on the setting
-			if(_useSecureClient){client = PubSubClient(_currentNet.mqttHost, _currentNet.mqttPort, wifiClientSecure);}
+			if(_useSecureClient) {
+				client = PubSubClient(_currentNet.mqttHost, _currentNet.mqttPort, wifiClientSecure);
+				if (_caFile) {
+					if(wifiClientSecure.loadCACert(_caFile)) {
+						debugPrintln("Loaded Cert into client");
+					} else {
+						debugPrintln("Unable to load Cert into client");
+					}
+				} else {
+					debugPrintln("No CA file");
+				}
+			}
 			else{client = PubSubClient(_currentNet.mqttHost, _currentNet.mqttPort, wifiClient);}
 
 			//set the mqtt message callback if needed
@@ -342,6 +353,18 @@ void ESPHelper::useSecureClient(const char* fingerprint){
 
 	//flag use of secure client
 	_useSecureClient = true;
+}
+
+void ESPHelper::useCustomCaCert(const char* cert){
+	SPIFFS.begin();
+	_caFile = SPIFFS.open(cert, "r");
+	if(!_caFile) {
+		debugPrintln("Couldn't load Cert");
+		return;
+	} else {
+		debugPrint("Loaded Cert");
+		debugPrintln(cert);
+	}
 }
 
 //enables and sets up broadcast mode rather than station mode. This allows users to create a network from the ESP

--- a/src/ESPHelper.h
+++ b/src/ESPHelper.h
@@ -38,6 +38,7 @@
 #include <ArduinoOTA.h>
 #include <PubSubClient.h>
 #include <WiFiClientSecure.h>
+#include "FS.h"
 
 
 
@@ -285,6 +286,8 @@ public:
 
 	void useSecureClient(const char* fingerprint);
 
+	void useCustomCaCert(const char* cert);
+
 	void broadcastMode(const char* ssid, const char* password, const IPAddress ip);
 	void disableBroadcast();
 
@@ -374,6 +377,7 @@ private:
 	WiFiClientSecure wifiClientSecure;
 	const char* _fingerprint;
 	bool _useSecureClient = false;
+	File _caFile;
 
 
 	String _clientName;


### PR DESCRIPTION
The certificate must be in DER format, and uploaded to SPIFFS.
`void useCustomCaCert(const char* cert);` accepts a path to a certificate stored on the SPIFFS filesystem.
In the `ESPHelper::begin()` method, if the secureClient is used and the certificate file exists on SPIFFS, it will be loaded into the client.
